### PR TITLE
Upgrade packages and add gulp bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Bower dependency directory (https://bower.io/)
+bower_components
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+# Optional npm cache directory
+.npm

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,37 +4,52 @@ var gulp = require("gulp");
 var autoprefixer = require('gulp-autoprefixer');
 const concat = require('gulp-concat');
 const cssmin = require('gulp-cssmin');
+const bump = require('gulp-bump');
 
 /** Autoprefix CSS + minification */
-gulp.task('css', function () {
-    gulp.src(['icss.css','./css/*.css'])
+function css() {
+    return gulp
+        .src(['icss.css','./css/*.css'])
         .pipe(autoprefixer('last 10 versions', 'ie 10'))
 		.pipe(concat('iconicss.css'))
 		.pipe(gulp.dest('./dist'));
-});
+};
 
-gulp.task('cssmin', function () {
-    gulp.src(['icss.css','./css/*.css'])
+function mincss() {
+    return gulp
+        .src(['icss.css','./css/*.css'])
         .pipe(autoprefixer({
-            browsers: ['last 2 versions'],
             cascade: false
 		}))
 		.pipe(concat('iconicss.min.css'))
 		.pipe(cssmin())
 		.pipe(gulp.dest('./dist'));
-});
+};
 
 /** Create a custom build using the custom dir */
-gulp.task('custom', function () {
-    gulp.src(['icss.css','./custom/*.css'])
+function custom() {
+    return gulp
+        .src(['icss.css','./custom/*.css'])
         .pipe(autoprefixer({
-            browsers: ['last 2 versions'],
             cascade: false
 		}))
 		.pipe(concat('myiconicss.css'))
 		.pipe(cssmin())
 		.pipe(gulp.dest('./dist'));
-});
+};
 
-// The default task that will be run if no task is supplied
-gulp.task("default", ["css", "cssmin"]);
+function dobump() {
+    return gulp
+        .src('./package.json')
+        .pipe(bump({type:'minor'}))
+        .pipe(gulp.dest('./'));
+
+};
+
+const build = gulp.series(gulp.parallel(css, mincss));
+
+exports.css = css;
+exports.mincss = mincss;
+exports.custom = custom;
+exports.dobump = dobump;
+exports.default = build;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,13 @@
     "icon-set",
     "purecss"
   ],
+  "browserslist": [
+    "last 2 versions",
+    "IE >= 10",
+    "edge >= 16",
+    "Firefox >= 60",
+    "Chrome >= 70"
+  ],
   "author": "Jean-Marc Viglino (https://github.com/Viglino)",
   "license": "MIT",
   "bugs": {
@@ -24,8 +31,9 @@
   "homepage": "https://github.com/Viglino/iconicss",
   "dependencies": {},
   "devDependencies": {
-    "gulp": "^3.9.1",
-    "gulp-autoprefixer": "^4.0.0",
+    "gulp": "^4.0.2",
+    "gulp-autoprefixer": "^7.0.1",
+    "gulp-bump": "^3.1.3",
     "gulp-concat": "^2.6.1",
     "gulp-cssmin": "^0.2.0"
   }


### PR DESCRIPTION
Hi,

- upgraded gulp to 4 so its usable from node 12.
- upgraded gulp-autoprefixer to 7 and placed browserslist in package.json as is recommended now
- added gulp bump to easily increase version numbers.

gulp build is the default task now which builds both normal and minified css.
gulp dobump increases the minor version number

I didnt execute above commands yet, but if you do 'gulp dobump' and check it in then npm will see this as e new release.
